### PR TITLE
Unique connection pool

### DIFF
--- a/mysql/src/main/java/com/timgroup/eventstore/mysql/StacksConfiguredDataSource.java
+++ b/mysql/src/main/java/com/timgroup/eventstore/mysql/StacksConfiguredDataSource.java
@@ -3,14 +3,31 @@ package com.timgroup.eventstore.mysql;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.typesafe.config.Config;
 
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
 
-public final class StacksConfiguredDataSource {
-    private StacksConfiguredDataSource() { /* prevent instantiation */ }
+public final class StacksConfiguredDataSource implements AutoCloseable {
 
-    public static ComboPooledDataSource pooledMasterDb(Properties properties, String configPrefix) {
+    private static Map<String, StacksConfiguredDataSource> dataSources = new ConcurrentHashMap<>();
+
+    private final String id;
+    public final ComboPooledDataSource dataSource;
+
+    private StacksConfiguredDataSource(String id, ComboPooledDataSource dataSource) {
+        this.id = id;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void close() {
+        dataSources.remove(id);
+        dataSource.close();
+    }
+
+    public static StacksConfiguredDataSource pooledMasterDb(Properties properties, String configPrefix) {
         String prefix = configPrefix;
 
         if (properties.getProperty(prefix + "hostname") == null) {
@@ -30,7 +47,7 @@ public final class StacksConfiguredDataSource {
         );
     }
 
-    public static ComboPooledDataSource pooledReadOnlyDb(Properties properties, String configPrefix) {
+    public static StacksConfiguredDataSource pooledReadOnlyDb(Properties properties, String configPrefix) {
         String prefix = configPrefix;
 
         if (properties.getProperty(prefix + "read_only_cluster") == null) {
@@ -50,7 +67,7 @@ public final class StacksConfiguredDataSource {
         );
     }
 
-    public static ComboPooledDataSource pooledMasterDb(Config config) {
+    public static StacksConfiguredDataSource pooledMasterDb(Config config) {
         return pooled(
                 config.getString("hostname"),
                 config.getInt("port"),
@@ -61,7 +78,7 @@ public final class StacksConfiguredDataSource {
         );
     }
 
-    public static ComboPooledDataSource pooledReadOnlyDb(Config config) {
+    public static StacksConfiguredDataSource pooledReadOnlyDb(Config config) {
         return pooled(
                 config.getString("read_only_cluster"),
                 config.getInt("port"),
@@ -72,7 +89,15 @@ public final class StacksConfiguredDataSource {
         );
     }
 
-    private static ComboPooledDataSource pooled(String hostname, int port, String username, String password, String database, String driver) {
+    private static StacksConfiguredDataSource pooled(String hostname, int port, String username, String password, String database, String driver) {
+        return dataSources.computeIfAbsent(idFromProperties(hostname, port, username, database, driver), id -> newComboPooledDataSource(id, hostname, port, username, password, database, driver));
+    }
+
+    private static String idFromProperties(String hostname, int port, String username, String database, String driver) {
+        return hostname + port + username + database + driver;
+    }
+
+    private static StacksConfiguredDataSource newComboPooledDataSource(String id, String hostname, int port, String username, String password, String database, String driver) {
         ComboPooledDataSource dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(format("jdbc:mysql://%s:%d/%s?rewriteBatchedStatements=true",
                 hostname,
@@ -87,6 +112,7 @@ public final class StacksConfiguredDataSource {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
-        return dataSource;
+        return new StacksConfiguredDataSource(id, dataSource);
     }
+
 }

--- a/mysql/src/main/java/com/timgroup/eventstore/mysql/legacy/LegacyMysqlEventSource.java
+++ b/mysql/src/main/java/com/timgroup/eventstore/mysql/legacy/LegacyMysqlEventSource.java
@@ -1,22 +1,15 @@
 package com.timgroup.eventstore.mysql.legacy;
 
-import java.util.Collection;
-import java.util.Properties;
-
-import com.mchange.v2.c3p0.ComboPooledDataSource;
-import com.timgroup.eventstore.api.EventCategoryReader;
-import com.timgroup.eventstore.api.EventReader;
-import com.timgroup.eventstore.api.EventSource;
-import com.timgroup.eventstore.api.EventStreamReader;
-import com.timgroup.eventstore.api.EventStreamWriter;
-import com.timgroup.eventstore.api.PositionCodec;
-import com.timgroup.eventstore.api.StreamId;
+import com.timgroup.eventstore.api.*;
 import com.timgroup.eventstore.mysql.ConnectionProvider;
 import com.timgroup.eventstore.mysql.StacksConfiguredDataSource;
 import com.timgroup.tucker.info.Component;
 import com.timgroup.tucker.info.component.DatabaseConnectionComponent;
 import com.typesafe.config.Config;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Properties;
 
 import static java.util.Collections.singletonList;
 
@@ -131,22 +124,22 @@ public class LegacyMysqlEventSource implements EventSource {
     }
 
 
-    private static LegacyPooledMysqlEventSource pooledEventSource(ComboPooledDataSource dataSource, String tableName, StreamId pretendStreamId, String name, int batchSize) {
+    private static LegacyPooledMysqlEventSource pooledEventSource(StacksConfiguredDataSource stacksConfiguredDataSource, String tableName, StreamId pretendStreamId, String name, int batchSize) {
         try {
-            new LegacyMysqlEventStoreSetup(dataSource::getConnection, tableName).lazyCreate();
+            new LegacyMysqlEventStoreSetup(stacksConfiguredDataSource.dataSource::getConnection, tableName).lazyCreate();
         } catch (Exception e) {
             LoggerFactory.getLogger(LegacyMysqlEventSource.class).warn("Failed to ensure ES scheme is created", e);
         }
 
-        return new LegacyPooledMysqlEventSource(dataSource, tableName, pretendStreamId, batchSize, name);
+        return new LegacyPooledMysqlEventSource(stacksConfiguredDataSource, tableName, pretendStreamId, batchSize, name);
     }
 
     public static final class LegacyPooledMysqlEventSource extends LegacyMysqlEventSource implements AutoCloseable {
-        private final ComboPooledDataSource dataSource;
+        private final StacksConfiguredDataSource dataSource;
 
-        public LegacyPooledMysqlEventSource(ComboPooledDataSource dataSource, String tableName, StreamId pretendStreamId, int batchSize, String name) {
-            super(dataSource::getConnection, tableName, pretendStreamId, batchSize, name);
-            this.dataSource = dataSource;
+        public LegacyPooledMysqlEventSource(StacksConfiguredDataSource stacksConfiguredDataSource, String tableName, StreamId pretendStreamId, int batchSize, String name) {
+            super(stacksConfiguredDataSource.dataSource::getConnection, tableName, pretendStreamId, batchSize, name);
+            this.dataSource = stacksConfiguredDataSource;
         }
 
         @Override

--- a/mysql/src/test/java/com/timgroup/eventstore/mysql/StacksConfiguredDataSourceTest.java
+++ b/mysql/src/test/java/com/timgroup/eventstore/mysql/StacksConfiguredDataSourceTest.java
@@ -1,0 +1,28 @@
+package com.timgroup.eventstore.mysql;
+
+import com.typesafe.config.Config;
+import org.junit.Test;
+
+import static com.typesafe.config.ConfigFactory.parseString;
+import static com.typesafe.config.ConfigParseOptions.defaults;
+import static com.typesafe.config.ConfigSyntax.PROPERTIES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsSame.sameInstance;
+
+public class StacksConfiguredDataSourceTest {
+
+    @Test
+    public void only_creates_one_datasource_per_unique_configuration() {
+
+        Config config = parseString(
+                "hostname=localhost\n" +
+                        "port=3306\n" +
+                        "database=sql_eventstore\n" +
+                        "username=\n" +
+                        "password=\n" +
+                        "driver=com.mysql.jdbc.Driver", defaults().setSyntax(PROPERTIES));
+
+        assertThat(StacksConfiguredDataSource.pooledMasterDb(config), sameInstance(StacksConfiguredDataSource.pooledMasterDb(config)));
+    }
+
+}


### PR DESCRIPTION
Currently multiple event sources within the  same application all have their own connection pool. I can't see why this would be necessary, but please correct me if I'm wrong. 

Currently this is causing one app to maintain 18 open connections with the database. Multiply this by 6 instances and we will start to see alerts on the number of open connections.

This branch keeps the connection pools that are instantiated within a running JVM in a cache will return the same pool if the connection parameters (host, database, port, user and driver) are identical.